### PR TITLE
Add compile time option to select which device is used when loading f…

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -3,6 +3,11 @@ version := 1.xx
 endif
 export version
 
+ifndef d64devnr
+d64devnr := 8
+endif
+export d64devnr
+
 ######################################
 # target
 ######################################
@@ -81,7 +86,8 @@ AS_DEFS =
 
 # C defines
 C_DEFS =  \
--DSTM32F405xx
+-DSTM32F405xx \
+-DD64DEVNR=${d64devnr}
 
 # AS includes
 AS_INCLUDES =

--- a/firmware/loader.c
+++ b/firmware/loader.c
@@ -364,7 +364,7 @@ static uint32_t crt_calc_flash_crc(uint8_t crt_banks)
 static void basic_load(const char *filename)
 {
     // BASIC commands to run at start-up
-    sprint((char *)dat_buffer, "LOAD\"%s\",8,1%cRUN%c", filename, 0, 0);
+    sprint((char *)dat_buffer, "LOAD\"%s\",%d,1%cRUN%c", filename, D64DEVNR, 0, 0);
 }
 
 static void basic_no_commands(void)

--- a/launcher/Makefile
+++ b/launcher/Makefile
@@ -5,6 +5,11 @@ ifndef version
 version := 1.xx
 endif
 
+ifndef d64devnr
+d64devnr := 8
+endif
+
+
 name := KungFuLauncher_v$(version)
 
 ld_config := ld.crt.cfg
@@ -24,7 +29,8 @@ inc      += ../3rd_party/libef3usb/src
 libef3usb := ../3rd_party/libef3usb/libef3usb.lib
 
 INCLUDE  := $(addprefix -I,$(inc))
-DEFINE   := -DVERSION=\"${version}\"
+CDEFINE  := -DVERSION=\"${version}\" 
+ADEFINE  := -DD64DEVNR=${d64devnr}
 
 .PHONY: all
 all: build/$(name).bin
@@ -35,15 +41,15 @@ all: build/$(name).bin
 headers := $(wildcard *.h)
 
 build/%.s: %.c $(headers) | build
-	cc65 -t c64 -T -O --static-locals $(INCLUDE) $(DEFINE) -o $@ $<
+	cc65 -t c64 -T -O --static-locals $(INCLUDE) $(CDEFINE) -o $@ $<
 
 ###############################################################################
 build/%.o: build/%.s | build
-	ca65 -t c64 $(INCLUDE) -o $@ $<
+	ca65 -t c64 $(INCLUDE) $(ADEFINE) -o $@ $<
 
 ###############################################################################
 build/%.o: %.s | build
-	ca65 -t c64 $(INCLUDE) -o $@ $<
+	ca65 -t c64 $(INCLUDE) $(ADEFINE) -o $@ $<
 
 ###############################################################################
 #

--- a/launcher/disk.s
+++ b/launcher/disk.s
@@ -429,7 +429,8 @@ disk_api_end:
 .proc kff_open
 kff_open:
 	lda FA
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
         beq @kff_device                 ; Device 8
 
 @normal_open:
@@ -515,7 +516,8 @@ kff_close:
         bne :-
 
         lda FAT,x                       ; Lookup device
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
         bne @normal_close               ; Not device 8
 
         lda SAT,x                       ; Lookup secondary address
@@ -554,7 +556,8 @@ kff_chkin:
         sta LA                          ; Store logical file
 
         lda FAT,x                       ; Lookup device
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
         bne @normal_chkin               ; Not device 8
 
         sta FA                          ; Store device
@@ -590,7 +593,8 @@ kff_chkin:
 kff_clrch:
         lda #$00                        ; Keyboard channel
 
-        ldx #$08
+;        ldx #$08
+        ldx #D64DEVNR
         cpx DFLTO                       ; Check output channel
         bne @check_input                ; Not device 8
         sta DFLTO                       ; Don't send commands to the serial bus
@@ -623,7 +627,8 @@ kff_basin:
         lda DFLTN
         beq keyboard                    ; Is keyboard
 
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
         bne normal_basin                ; Not device 8
 
 do_kff_basin:
@@ -697,7 +702,8 @@ normal_basin:
 .proc kff_getin
 kff_getin:
         lda DFLTN
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
         bne @normal_getin               ; Not device 8
 
 @kff_device:
@@ -730,7 +736,9 @@ kff_load:
         bne @normal_load                ; Verify operation (not load)
 
         lda FA
-        cmp #$08
+;        cmp #$08
+        cmp #D64DEVNR
+
         beq @kff_device                 ; Device 8
 
 @normal_load:


### PR DESCRIPTION
…rom D64 files. This avoids conflicts with existing drives/SD2IEC devices.

Use 'make d64devnr=x' to set device to x (4..30 are valid). When omitted it defaults to 8