### PR TITLE
Expert and Georam support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Georam expansion only has 64kbyte due to microcontroller limitations.
 
 Currently 2 expansions can be selected in the setting menu (F5). Doing a kill (F8) will start this cart.
 
-Expert cartridge starts in 'PRG' mode, after the first reset it is switched to 'ON' mode. Jumping into the menu (using the Menu button) will reset the mode to 'PRG' (if F8 is pressed there)
+Expert cartridge starts in 'PRG' mode, after the first reset it is switched to 'ON' mode. Jumping into the menu (using the Menu button) will reset the mode to 'PRG' (if F8 is pressed there). To start the payload use the 'RESTORE' key (freeze button does nothing)
 
 Georam only has 64kbyte of memory for now. 
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following cartridge types are currently supported:
 * Super Snapshot v5
 * Comal-80
 * EasyFlash
+* Expert Cartridge
+* Georam expansion module (only the first 64K is available)
 
 ## Supported File Types
 The following file types are currently supported:
@@ -70,6 +72,16 @@ Use it at your own risk!
 Kung Fu Flash will work with the PAL version of the Commodore 64 or Commodore 128. Support for the NTSC version is still considered experimental.
 
 Disk drive emulation is using kernal vectors and will not work with fast loaders or software that uses direct hardware access which a lot of games does. Currently REL files are not supported and there is only limited write support.
+
+Georam expansion only has 64kbyte due to microcontroller limitations.
+
+## Expansion
+
+Currently 2 expansions can be selected in the setting menu (F5). Doing a kill (F8) will start this cart.
+
+Expert cartridge starts in 'PRG' mode, after the first reset it is switched to 'ON' mode. Jumping into the menu (using the Menu button) will reset the mode to 'PRG' (if F8 is pressed there)
+
+Georam only has 64kbyte of memory for now. 
 
 ## Thanks
 Kung Fu Flash was based on or uses other open source projects:

--- a/firmware/cartridges/cartridge.c
+++ b/firmware/cartridges/cartridge.c
@@ -31,6 +31,8 @@
 #include "super_snapshot_5.c"
 #include "easyflash.c"
 #include "comal80.c"
+#include "georam.c"
+#include "expert.c"
 
 static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
 {
@@ -83,6 +85,16 @@ static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
             {
                 return ef_sdio_handler;
             }
+
+	case CRT_EXPERT_CARTRIDGE: 
+	    return expert_handler;
+
+	// expansions like expert and georam
+	case EXP_EXPERT: 
+	    return expert_handler;
+
+	case EXP_GEORAM: 
+	    return georam_handler;
     }
 
     return NULL;
@@ -119,6 +131,17 @@ static void (*crt_get_init(uint16_t cartridge_type)) (void)
 
         case CRT_EASYFLASH:
             return ef_init;
+
+	case CRT_EXPERT_CARTRIDGE: 
+	    return expert_init;
+
+	// expansions
+	case EXP_EXPERT: 
+	    return expert_expansion_init;
+
+	case EXP_GEORAM: 
+	    return georam_init;
+
     }
 
     return NULL;

--- a/firmware/cartridges/expert.c
+++ b/firmware/cartridges/expert.c
@@ -180,7 +180,6 @@ static inline bool expert_read_handler(uint32_t control, uint32_t addr)
     // access to IO1 releases NMI
     if (!(control & C64_IO1))
     {
-//	c64_irq_nmi(C64_IRQ_NMI_HIGH);
 	expert_mode=EXPERT_IDLE;
     }
 
@@ -221,7 +220,6 @@ static inline void expert_write_handler(uint32_t control, uint32_t addr, uint32_
     // access to IO1 releases NMI
     if (!(control & C64_IO1))
     {
-//	c64_irq_nmi(C64_IRQ_NMI_HIGH);
 	expert_mode=EXPERT_IDLE;
     }
 
@@ -252,7 +250,6 @@ static void expert_expansion_init(void)
 {
 	int i=0;
 
-//	crt_ptr = crt_banks[0];
 	crt_ptr = (uint8_t*)scratch_buf+8192;
 
 	if(expert_signature())

--- a/firmware/cartridges/expert.c
+++ b/firmware/cartridges/expert.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2019-2020 Kim Jørgensen
+ *
+ * Expert cart support written and (c) 2020 Chris van Dongen
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define EXPERT_IDLE		0	// waiting for button
+#define EXPERT_ACTIVE		1	// button pressed
+#define EXPERT_ULTIMAX		2	// ultimax 
+#define EXPERT_PROGRAM		3	// RAM can be programmed
+
+static uint32_t expert_mode;
+
+static uint32_t const expert_modes[4] =
+{
+    STATUS_LED_OFF|CRT_PORT_NONE,		// idle
+    STATUS_LED_ON|CRT_PORT_NONE,		// active
+    STATUS_LED_ON|CRT_PORT_ULTIMAX,		// memacces at 0xe000 or 0x8000
+    STATUS_LED_OFF|CRT_PORT_NONE		// program
+};
+
+
+// we need some extra cycles to switch out ultimax mode
+#define PHI2_CPU_END_EXPERT	(PHI2_CPU_END-3)
+
+// we need a special cart handler 
+#define C64_VIC_BUS_HANDLER_EXPERT(name)                                                \
+        C64_VIC_BUS_HANDLER_EXPERT_(name##_handler, name##_vic_read_handler,            \
+                                name##_read_handler, name##_early_write_handler,    \
+                                name##_write_handler, C64_VIC_DELAY)
+
+
+// This supports VIC-II reads from the cartridge (i.e. character and sprite data)
+// but uses 100% CPU - other interrupts are not served due to the interrupt priority
+#define C64_VIC_BUS_HANDLER_EXPERT_(name, vic_read_handler, read_handler,           \
+                                early_write_handler, write_handler, vic_delay)  \
+void name(void)                                                                 \
+{                                                                               \
+    /* As we don't return from this handler, we need to do this here */         \
+    c64_reset(false);                                                           \
+    /* Use debug cycle counter which is faster to access than timer */          \
+    DWT->CYCCNT = TIM1->CNT;                                                    \
+    __DMB();                                                                    \
+    while (true)                                                                \
+    {                                                                           \
+        /* Wait for CPU cycle */                                                \
+        while (DWT->CYCCNT < PHI2_CPU_START);                                   \
+        uint32_t addr = c64_addr_read();                                        \
+        COMPILER_BARRIER();                                                     \
+        uint32_t control = c64_control_read();                                  \
+        /* Check if CPU has the bus (no bad line) */                            \
+        if ((control & (C64_BA|C64_WRITE)) == (C64_BA|C64_WRITE))               \
+        {                                                                       \
+            if (read_handler(control, addr))                                    \
+            {                                                                   \
+                /* Release bus when phi2 is going low */                        \
+                while (DWT->CYCCNT < PHI2_CPU_END_EXPERT);                      \
+                c64_data_input();                                               \
+            }                                                                   \
+        }                                                                       \
+        else if (!(control & C64_WRITE))                                        \
+        {                                                                       \
+            early_write_handler();                                              \
+            uint32_t data = c64_data_read();                                    \
+            write_handler(control, addr, data);                                 \
+            while (DWT->CYCCNT < PHI2_CPU_END_EXPERT);                          \
+        }                                                                       \
+        /* VIC-II has the bus */                                                \
+        else                                                                    \
+        {                                                                       \
+            /* Wait for the control bus to become stable */                     \
+            C64_CPU_VIC_DELAY()                                                 \
+            control = c64_control_read();                                       \
+            if (vic_read_handler(control, addr))                                \
+            {                                                                   \
+                /* Release bus when phi2 is going low */                        \
+                while (DWT->CYCCNT < PHI2_CPU_END_EXPERT);                      \
+                c64_data_input();                                               \
+            }                                                                   \
+        }                                                                       \
+	c64_crt_control(expert_modes[expert_mode]); /* reset ultimax */         \
+        if (control & MENU_BTN)                                                 \
+        {                                                                       \
+            /* Allow the menu button interrupt handler to run */                \
+            c64_interface(false);                                               \
+            break;                                                              \
+        }                                                                       \
+        /* Wait for VIC-II cycle */                                             \
+        while (TIM1->CNT >= 80);                                                \
+        DWT->CYCCNT = TIM1->CNT;                                                \
+        __DMB();                                                                \
+        while (DWT->CYCCNT < PHI2_VIC_START);                                   \
+        addr = c64_addr_read();                                                 \
+        COMPILER_BARRIER();                                                     \
+        /* Ideally, we would always wait until PHI2_VIC_DELAY here which is */  \
+        /* required when the VIC-II has the bus, but we need more cycles */     \
+        /* in C128 2 MHz mode where data is read from flash */                  \
+        vic_delay();                                                            \
+        control = c64_control_read();                                           \
+        if (vic_read_handler(control, addr))                                    \
+        {                                                                       \
+            /* Release bus when phi2 is going high */                           \
+            while (DWT->CYCCNT < PHI2_VIC_END);                                 \
+            c64_data_input();                                                   \
+        }                                                                       \
+    }                                                                           \
+    TIM1->SR = ~TIM_SR_CC3IF;                                                   \
+    __DMB();                                                                    \
+}
+
+
+/*************************************************
+* Make it programmable the first boot; next boot
+* it is activated
+*************************************************/
+
+#define EXPERT_SIGNATURE  "Expert:booted"
+
+// we use scratch_buf+10 as scratch_buff seems to be overwritten
+// probably we need a better way?
+
+static inline void set_expert_signature(void)
+{
+    memcpy(scratch_buf+10, EXPERT_SIGNATURE, sizeof(EXPERT_SIGNATURE));
+}
+
+static inline bool expert_signature(void)
+{
+    return memcmp(scratch_buf+10, EXPERT_SIGNATURE, sizeof(EXPERT_SIGNATURE)) == 0;
+}
+
+static inline void invalidate_expert_signature(void)
+{
+    scratch_buf[10] = 0;
+}
+
+
+
+
+/*************************************************
+* C64 bus read callback (VIC-II cycle)
+*************************************************/
+static inline bool expert_vic_read_handler(uint32_t control, uint32_t addr)
+{
+
+    // no vic read needed
+
+    return false;
+}
+
+/*************************************************
+* C64 bus read callback (CPU cycle)
+*************************************************/
+static inline bool expert_read_handler(uint32_t control, uint32_t addr)
+{
+    // when active, the kernal and $8000 is presented in ultimax mode
+    if((expert_mode==EXPERT_ACTIVE)&&(((addr&0xe000)==0xe000)||((addr&0xe000)==0x8000)))
+    {
+	c64_crt_control(expert_modes[EXPERT_ULTIMAX]); /* switch to ultimax if we access kernal or 0x8000 */
+        c64_data_write(crt_ptr[addr & 0x1fff]);
+        return true;
+    }
+
+    // access to IO1 releases NMI
+    if (!(control & C64_IO1))
+    {
+//	c64_irq_nmi(C64_IRQ_NMI_HIGH);
+	expert_mode=EXPERT_IDLE;
+    }
+
+    // handle external NMI (freeze button doesn't work)
+    if ((!((GPIOA->IDR)&GPIO_IDR_ID10))&&(expert_mode==EXPERT_IDLE)) 		// nmi is on gpioa-10
+    {
+        freezer_state = FREEZE_START;
+    }
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback (early)
+*************************************************/
+static inline void expert_early_write_handler(void)
+{
+    // Use 3 consecutive writes to detect IRQ/NMI
+    if (freezer_state && ++freezer_state == FREEZE_3_WRITES)
+    {
+	expert_mode=EXPERT_ACTIVE;
+	c64_crt_control(expert_modes[expert_mode]);
+        freezer_state = FREEZE_RESET;
+    }
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+static inline void expert_write_handler(uint32_t control, uint32_t addr, uint32_t data)
+{
+    if((expert_mode==EXPERT_ACTIVE)&&(((addr&0xe000)==0xe000)||((addr&0xe000)==0x8000)))
+    {
+	c64_crt_control(expert_modes[EXPERT_ULTIMAX]); /* switch to ultimax if we access kernal or roml */
+        crt_ptr[addr & 0x1fff]=data;
+    }
+
+    // access to IO1 releases NMI
+    if (!(control & C64_IO1))
+    {
+//	c64_irq_nmi(C64_IRQ_NMI_HIGH);
+	expert_mode=EXPERT_IDLE;
+    }
+
+    // if we are in program mode we are writable at 0x8000
+    if((expert_mode==EXPERT_PROGRAM)&&((addr&0xe000)==0x8000))
+    {
+	crt_ptr[addr & 0x1FFF]=data;
+    }
+}
+
+/*************************************************
+* init when loading an expert image
+*************************************************/
+static void expert_init(void)
+{
+	crt_ptr = crt_banks[0];
+
+	expert_mode=EXPERT_ACTIVE;
+
+	c64_crt_control(expert_modes[expert_mode]);
+}
+
+/*************************************************
+* init when called as expansion
+*************************************************/
+
+static void expert_expansion_init(void)
+{
+	int i=0;
+
+//	crt_ptr = crt_banks[0];
+	crt_ptr = (uint8_t*)scratch_buf+8192;
+
+	if(expert_signature())
+	{
+		expert_mode=EXPERT_ACTIVE;
+
+	}
+	else
+	{
+		expert_mode=EXPERT_PROGRAM;
+		set_expert_signature();
+
+		for(i=0; i<8192; i++) crt_ptr[i]=0x00;
+	}
+
+	c64_crt_control(expert_modes[expert_mode]);
+}
+
+// The freezer reads character data directly from the cartridge
+C64_VIC_BUS_HANDLER_EXPERT(expert)
+

--- a/firmware/cartridges/georam.c
+++ b/firmware/cartridges/georam.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019-2020 Kim Jørgensen
+ *
+ * Georam cart support written and (c) 2020 Chris van Dongen
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+static uint32_t ramoffset;
+static uint32_t bank, offset;
+
+
+/*************************************************
+* C64 bus read callback
+*************************************************/
+static inline bool georam_read_handler(uint32_t control, uint32_t addr)
+{
+    if (!(control & C64_IO1))
+    {
+        c64_data_write(crt_ptr[ramoffset+(addr & 0xff)]);
+        return true;
+    }
+
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+static inline void georam_write_handler(uint32_t control, uint32_t addr, uint32_t data)
+{
+    if (!(control & C64_IO1))
+    {
+        crt_ptr[ramoffset+(addr & 0x0ff)]=(uint8_t)data;
+    }
+
+
+    if (!(control & C64_IO2))
+    {
+	if(addr==0xDFFF) bank=data;		// range (0-127)
+	if(addr==0xDFFE) offset=data;		// range (0-63)
+
+	bank&=0x03;				// we only have 64k avail.
+
+	ramoffset=((bank&0x07F<<14)||((offset&0x03f)<<8));
+    }
+}
+
+/*************************************************
+* init georam
+*************************************************/
+void georam_init(void)
+{
+    // ram init
+    for(int i=0; i<(64*1024); i++)
+    {
+	crt_ptr[i]=0x00;
+    }
+
+    c64_crt_control(STATUS_LED_ON|CRT_PORT_NONE);
+    ramoffset=0;
+    offset=0;
+    bank=0;
+}
+
+// Support MAX cartridges where character and sprite data is read from the cartridge
+C64_VIC_BUS_HANDLER(georam)

--- a/firmware/file_types.h
+++ b/firmware/file_types.h
@@ -83,6 +83,11 @@ typedef enum {
     CRT_GMOD2
 } CRT_TYPE;
 
+#define EXP_NONE	0xFFF0
+#define EXP_GEORAM	0xFFF1
+#define EXP_EXPERT	0xFFF2
+#define EXP_RES		0xFFF3	// reserve
+
 typedef enum {
     CRT_CHIP_ROM = 0x00,
     CRT_CHIP_RAM,
@@ -140,11 +145,15 @@ typedef enum {
     DAT_FLAG_PERSIST_BASIC      = 0x01,
     DAT_FLAG_AUTOSTART_D64      = 0x02,
     DAT_FLAG_DEVICE_NUM_D64_1   = 0x04,
-    DAT_FLAG_DEVICE_NUM_D64_2   = 0x08
+    DAT_FLAG_DEVICE_NUM_D64_2   = 0x08,
+    DAT_FLAG_MEMEXPANSION_1     = 0x10,
+    DAT_FLAG_MEMEXPANSION_2     = 0x20,
 } DAT_FLAGS;
 
 #define DAT_FLAG_DEVICE_D64_POS 0x02
 #define DAT_FLAG_DEVICE_D64_MSK (0x03 << DAT_FLAG_DEVICE_D64_POS)
+#define DAT_FLAG_MEMEXPANSION_POS 0x04
+#define DAT_FLAG_MEMEXPANSION_MSK (0x03 << DAT_FLAG_MEMEXPANSION_POS)
 
 typedef enum {
     DAT_NONE = 0x00,
@@ -155,7 +164,7 @@ typedef enum {
     DAT_KERNAL,
     DAT_BASIC,
     DAT_KILL,
-    DAT_KILL_C128
+    DAT_KILL_C128,
 } DAT_BOOT_TYPE;
 
 typedef enum {

--- a/firmware/loader.c
+++ b/firmware/loader.c
@@ -725,16 +725,41 @@ static bool c64_set_mode(void)
         break;
 
         case DAT_KILL:
-        {
-            c64_disable();
-            // Also unstoppable!
-            c64_crt_control(STATUS_LED_OFF|CRT_PORT_8K);
-            c64_reset(false);
-            delay_ms(300);
-            c64_crt_control(CRT_PORT_NONE);
-            result = true;
-        }
-        break;
+	{
+		uint16_t expansion;
+
+		if((dat_file.flags&DAT_FLAG_MEMEXPANSION_MSK)==0)	// no expansion is selected
+		{
+		    c64_disable();
+		    // Also unstoppable!
+		    c64_crt_control(STATUS_LED_OFF|CRT_PORT_8K);
+		    c64_reset(false);
+		    delay_ms(300);
+		    c64_crt_control(CRT_PORT_NONE);
+		    result = true;
+		}
+		else
+		{
+		    if (!c64_is_reset())
+		    {
+		        // Disable VIC-II output if C64 has been started (needed for FC3)
+		        c64_interface(true);
+		        c64_send_wait_for_reset();
+		        c64_disable();
+		    }
+
+		    expansion=0xFFF0+((dat_file.flags&DAT_FLAG_MEMEXPANSION_MSK)>>DAT_FLAG_MEMEXPANSION_POS);
+		    //expansion=0xFFF0+((dat_file.flags&0x30)>>4);
+
+		    c64_crt_control(STATUS_LED_ON|CRT_PORT_NONE);
+		    // Try prevent triggering bug in H.E.R.O. No effect at power-on though
+		    c64_sync_with_vic();
+		    crt_install_handler(expansion, CRT_FLAG_NONE);
+		    c64_enable();
+		    result = true;
+		}
+	}
+	break;
 
         case DAT_KILL_C128:
         {

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -55,6 +55,7 @@ int main(void)
 
     if (!auto_boot())
     {
+	invalidate_expert_signature();	// pressing menu will invalidate Expert mem
         c64_enable();
         menu_loop();
     }

--- a/firmware/menu_settings.c
+++ b/firmware/menu_settings.c
@@ -97,6 +97,41 @@ static bool settings_save(OPTIONS_STATE *state, OPTIONS_ELEMENT *element, uint8_
     return false;
 }
 
+static const char * settings_memexpansion_text(void)
+{
+    sprint(scratch_buf, "Expansion on F8: %s",
+           ((settings_flags & DAT_FLAG_MEMEXPANSION_2) ?				
+		((settings_flags & DAT_FLAG_MEMEXPANSION_1) ? "---" : "Expert") :	
+		((settings_flags & DAT_FLAG_MEMEXPANSION_1) ? "GEORam-64K" : "None")) );
+
+    return scratch_buf;
+}
+
+static bool settings_memexpansion_change(OPTIONS_STATE *state, OPTIONS_ELEMENT *element, uint8_t flags)
+{
+	uint8_t expansion;
+/*
+	expansion=(settings_flags & 0x30);	//DAT_FLAG_MEMEXPANSION_MSK);
+	expansion+=0x10;
+	expansion&=0x30;	//DAT_FLAG_MEMEXPANSION_MSK;
+	settings_flags = (settings_flags & 0xCF ) | expansion;
+*/
+
+expansion = (settings_flags & DAT_FLAG_MEMEXPANSION_MSK) >> DAT_FLAG_MEMEXPANSION_POS;
+expansion ++;
+if(expansion==3) expansion=0;		// slot 4 had no handler so roll over
+expansion <<= DAT_FLAG_MEMEXPANSION_POS;
+expansion &= DAT_FLAG_MEMEXPANSION_MSK;
+
+	settings_flags = (settings_flags & ~DAT_FLAG_MEMEXPANSION_MSK) | expansion;
+
+
+
+    options_element_text(element, settings_memexpansion_text());
+    menu_state->dir(menu_state); // Refresh settings
+    return false;
+}
+
 static void handle_settings(void)
 {
     settings_flags = dat_file.flags;
@@ -105,6 +140,7 @@ static void handle_settings(void)
     options_add_text_element(options, settings_basic_change, settings_basic_text());
     options_add_text_element(options, settings_autostart_change, settings_autostart_text());
     options_add_text_element(options, settings_device_change, settings_device_text());
+    options_add_text_element(options, settings_memexpansion_change, settings_memexpansion_text());
     options_add_text_element(options, settings_save, "Save");
     options_add_dir(options, "Cancel");
     handle_options(options);

--- a/firmware/menu_settings.c
+++ b/firmware/menu_settings.c
@@ -109,23 +109,15 @@ static const char * settings_memexpansion_text(void)
 
 static bool settings_memexpansion_change(OPTIONS_STATE *state, OPTIONS_ELEMENT *element, uint8_t flags)
 {
-	uint8_t expansion;
-/*
-	expansion=(settings_flags & 0x30);	//DAT_FLAG_MEMEXPANSION_MSK);
-	expansion+=0x10;
-	expansion&=0x30;	//DAT_FLAG_MEMEXPANSION_MSK;
-	settings_flags = (settings_flags & 0xCF ) | expansion;
-*/
+    uint8_t expansion;
 
-expansion = (settings_flags & DAT_FLAG_MEMEXPANSION_MSK) >> DAT_FLAG_MEMEXPANSION_POS;
-expansion ++;
-if(expansion==3) expansion=0;		// slot 4 had no handler so roll over
-expansion <<= DAT_FLAG_MEMEXPANSION_POS;
-expansion &= DAT_FLAG_MEMEXPANSION_MSK;
+    expansion = (settings_flags & DAT_FLAG_MEMEXPANSION_MSK) >> DAT_FLAG_MEMEXPANSION_POS;
+    expansion ++;
+    if(expansion==3) expansion=0;		// slot 4 had no handler so roll over
+    expansion <<= DAT_FLAG_MEMEXPANSION_POS;
+    expansion &= DAT_FLAG_MEMEXPANSION_MSK;
 
-	settings_flags = (settings_flags & ~DAT_FLAG_MEMEXPANSION_MSK) | expansion;
-
-
+    settings_flags = (settings_flags & ~DAT_FLAG_MEMEXPANSION_MSK) | expansion;
 
     options_element_text(element, settings_memexpansion_text());
     menu_state->dir(menu_state); // Refresh settings


### PR DESCRIPTION
I have add support for the Expert cartridge and Georam Cartridge (only 64K for now). Expert cart can be loaded when the appropriate crt is selected in the directory menu, but it can also be programmed in through the C64 itself. For that the settingsmenu has a new setting 'Expansion on F8'. This setting controls if nothing (none option), expert cartridge (expert option) or Georam (Georam-64K option) is active when the F8 is pressed in the menu.

In order to program the Expert cart make sure the Expert is selected in the Settings menu and persistent BASIC selection is yes. Press F8 somewhere in the menu and you get into regular C64 mode. The cart is now in 'Program' mode. Load the Expert disk and select the appropriate payload you want. when the programming is done reset your commodore as requested. The payload should be executed. Entering the Menu wil reset this flag to 'PRG' mode.

A few notes:

- I noticed the expert doesn't play wel along with Jiffydos active, make sure stock kernal is used.
- Also I couldn't get the freeze button to work properly, so only the restore key and fiddling the CIA works.

The Georam is for now only 64K big and rolls over on every 64K which makes it not very usefull at the moment. I think we can push it to about 160K in the end (but requires a bit of rework of the code). Dunno if it is usefull then too, but for simple disk-copying or native compiler like TMP it will suffice. 512K (which is the smallest Georam) is out of reach without a major hardware change.

I did my development on a PAL SX64 which can be picky on the KFF cart. NTSC is not tested at all.

