### PR TITLE
Added support for WarpSpeed cartridge

### DIFF
--- a/firmware/cartridges/cartridge.c
+++ b/firmware/cartridges/cartridge.c
@@ -18,6 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 #include "cartridge.h"
+/* ordered by cartridge id */
 #include "crt_normal.c"
 #include "action_replay_4x.c"
 #include "kcs_power_cartridge.c"
@@ -25,13 +26,13 @@
 #include "simons_basic.c"
 #include "epyx_fastload.c"
 #include "c64gs_system_3.c"
+#include "warpspeed.c"
 #include "dinamic.c"
 #include "zaxxon.c"
 #include "magic_desk.c"
 #include "super_snapshot_5.c"
 #include "easyflash.c"
 #include "comal80.c"
-#include "warpspeed.c"
 
 static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
 {
@@ -55,11 +56,11 @@ static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
         case CRT_EPYX_FASTLOAD:
             return epyx_handler;
 
-        case CRT_WARP_SPEED:
-            return warpspeed_handler;
-
         case CRT_C64_GAME_SYSTEM_SYSTEM_3:
             return c64gs_handler;
+
+        case CRT_WARP_SPEED:
+            return warpspeed_handler;
 
         case CRT_DINAMIC:
             return dinamic_handler;

--- a/firmware/cartridges/cartridge.c
+++ b/firmware/cartridges/cartridge.c
@@ -31,6 +31,7 @@
 #include "super_snapshot_5.c"
 #include "easyflash.c"
 #include "comal80.c"
+#include "warpspeed.c"
 
 static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
 {
@@ -53,6 +54,9 @@ static void (*crt_get_handler(uint16_t cartridge_type, bool vic_support)) (void)
 
         case CRT_EPYX_FASTLOAD:
             return epyx_handler;
+
+        case CRT_WARP_SPEED:
+            return warpspeed_handler;
 
         case CRT_C64_GAME_SYSTEM_SYSTEM_3:
             return c64gs_handler;
@@ -103,6 +107,9 @@ static void (*crt_get_init(uint16_t cartridge_type)) (void)
 
         case CRT_EPYX_FASTLOAD:
             return epyx_init;
+
+        case CRT_WARP_SPEED:
+            return warpspeed_init;
 
         case CRT_ZAXXON_SUPER_ZAXXON:
             return zaxxon_init;

--- a/firmware/cartridges/warpspeed.c
+++ b/firmware/cartridges/warpspeed.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019-2020 Kim Jørgensen and Sven Oliver (SvOlli) Moll
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/*
+ * Warp Speed has an easy hardware setup
+ * - a single 16k bank that can be turned on or off
+ * - read $DE00-$DFFF is a mirror of $9E00-$9FFF
+ * - write $DE00-$DEFF turns ROM on
+ * - write $DF00-$DFFF turns ROM off
+ * still it's twice as fast as JiffyDOS and can load to RAM at $D000-$DFFF,
+ * and also packs a lot of features.
+ * the original hardware features also a C128 mode, which can't be recreated
+ * using a crt image. 
+ */
+
+/*************************************************
+* C64 bus read callback
+*************************************************/
+static inline bool warpspeed_read_handler(uint32_t control, uint32_t addr)
+{
+    /* IO access */
+    if ((control & (C64_IO1|C64_IO2)) != (C64_IO1|C64_IO2))
+    {
+        /* $DE00-$DFFF are a mirror of $9E00-$9FFF */
+        c64_data_write(crt_ptr[addr & 0x1fff]);
+        return true;
+    }
+    
+    /* ROM access */
+    if ((control & (C64_ROML|C64_ROMH)) != (C64_ROML|C64_ROMH))
+    {
+        if (crt_rom_ptr)
+        {
+            c64_data_write(crt_rom_ptr[addr & 0x3fff]);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+static inline void warpspeed_write_handler(uint32_t control, uint32_t addr, uint32_t data)
+{
+    if (!(control & C64_IO1))
+    {
+        crt_rom_ptr = crt_ptr;
+        c64_crt_control(STATUS_LED_ON|CRT_PORT_16K);
+    }
+    
+    if (!(control & C64_IO2))
+    {
+        crt_rom_ptr = NULL;
+        c64_crt_control(STATUS_LED_ON|CRT_PORT_NONE);
+    }
+}
+
+static void warpspeed_init(void)
+{
+    c64_crt_control(STATUS_LED_ON|CRT_PORT_16K);
+    crt_rom_ptr = crt_ptr;
+}
+
+// Support MAX cartridges where character and sprite data is read from the cartridge
+C64_VIC_BUS_HANDLER(warpspeed)

--- a/firmware/cartridges/warpspeed.c
+++ b/firmware/cartridges/warpspeed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Kim Jørgensen and Sven Oliver (SvOlli) Moll
+ * Copyright (c) 2019-2021 Kim Jørgensen and Sven Oliver (SvOlli) Moll
  *
  * This software is provided 'as-is', without any express or implied
  * warranty.  In no event will the authors be held liable for any damages
@@ -46,11 +46,8 @@ static inline bool warpspeed_read_handler(uint32_t control, uint32_t addr)
     /* ROM access */
     if ((control & (C64_ROML|C64_ROMH)) != (C64_ROML|C64_ROMH))
     {
-        if (crt_rom_ptr)
-        {
-            c64_data_write(crt_rom_ptr[addr & 0x3fff]);
-            return true;
-        }
+        c64_data_write(crt_ptr[addr & 0x3fff]);
+        return true;
     }
 
     return false;
@@ -63,13 +60,10 @@ static inline void warpspeed_write_handler(uint32_t control, uint32_t addr, uint
 {
     if (!(control & C64_IO1))
     {
-        crt_rom_ptr = crt_ptr;
         c64_crt_control(STATUS_LED_ON|CRT_PORT_16K);
     }
-    
-    if (!(control & C64_IO2))
+    else if (!(control & C64_IO2))
     {
-        crt_rom_ptr = NULL;
         c64_crt_control(STATUS_LED_ON|CRT_PORT_NONE);
     }
 }
@@ -77,8 +71,6 @@ static inline void warpspeed_write_handler(uint32_t control, uint32_t addr, uint
 static void warpspeed_init(void)
 {
     c64_crt_control(STATUS_LED_ON|CRT_PORT_16K);
-    crt_rom_ptr = crt_ptr;
 }
 
-// Support MAX cartridges where character and sprite data is read from the cartridge
-C64_VIC_BUS_HANDLER(warpspeed)
+C64_BUS_HANDLER(warpspeed)


### PR DESCRIPTION
As a first test and to learn, I implemented Warp Speed, which is a rather simple from a hardware perspective, but still rather fast on loading (about 1/2 of the speed of Action Replay), even loads to the RAM at $D000-$DFFF and has quite some features.