### PR TITLE
Add information about (phi2) diagnostics to firmware readme

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -17,3 +17,11 @@ Use the DfuSE software from ST or [dfu-util](http://dfu-util.sourceforge.net/) t
 `dfu-util -a 0 -s 0x08000000 -D KungFuFlash_v1.xx.upd`
 
 Both jumpers should be removed after the firmware has been installed.
+
+## Diagnostic
+Introduced in firmware v1.27
+
+The diagnostic tool is started by pressing the menu button for 2 seconds (until the LED turns off) and is intended to help debug stability problems on some C64 models.
+The tool can also be started in a USB only mode if Kung Fu Flash refuses to start at all. In this mode debug data is send via USB only and the C64 should start normally (boot to Basic). This mode is started by pressing both the special and menu button for 2 seconds, then releasing the menu button followed by the special button.
+
+For reference the phi2 clock frequency should be around 985248 Hz for PAL and around 1022727 Hz for NTSC.


### PR DESCRIPTION
Add information about (phi2) diagnostics to firmware readme

It is difficult for users to find on only one specific release note (v1.27)
